### PR TITLE
Add run counter and donation reminder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 ## [0.10.2] - 2025-09-09
 ### Added
 - Track the number of times poketerm is run and remind heavy users to donate.
+### Changed
+- Limit donation reminders to three colorful messages for users exceeding 10,000 runs.
 
 ## [0.10.1] - 2025-09-09
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - Track the number of times poketerm is run and remind heavy users to donate.
 ### Changed
 - Limit donation reminders to three colorful messages for users exceeding 10,000 runs.
+- Update sponsorship link to https://github.com/sponsors/devarshi16.
 
 ## [0.10.1] - 2025-09-09
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.10.2] - 2025-09-09
+### Added
+- Track the number of times poketerm is run and remind heavy users to donate.
+
 ## [0.10.1] - 2025-09-09
 ### Added
 - Install poketerm into zsh startup files alongside bash equivalents.

--- a/src/main.py
+++ b/src/main.py
@@ -147,7 +147,7 @@ def main():
             print(colored("🎉 WOW! You've run poketerm over 10,000 times! 🎉", "yellow"))
             print(
                 colored(
-                    "☕ Consider sponsoring the project: https://github.com/sponsors/terminalwelcome",
+                    "☕ Consider sponsoring the project: https://github.com/sponsors/devarshi16",
                     "green",
                 )
             )

--- a/src/main.py
+++ b/src/main.py
@@ -128,6 +128,22 @@ def main():
         if line and not show_dialog:
             print(line)
 
+        # track how many times poketerm has been run
+        runs = 0
+        try:
+            runs = int(local_config["DEFAULTS"].get("runs", "0"))
+        except ValueError:
+            runs = 0
+        runs += 1
+        local_config["DEFAULTS"]["runs"] = str(runs)
+        with open(local_config_path, "w") as configfile:
+            local_config.write(configfile)
+        if runs > 10_000:
+            print(
+                "You've run poketerm over 10,000 times! Consider sponsoring at "
+                "https://github.com/sponsors/terminalwelcome"
+            )
+
 def change_config(args,path):
     config = cp.ConfigParser()
     config.read(path)

--- a/src/main.py
+++ b/src/main.py
@@ -136,13 +136,27 @@ def main():
             runs = 0
         runs += 1
         local_config["DEFAULTS"]["runs"] = str(runs)
+
+        # remind frequent users to sponsor only a few times
+        reminders = 0
+        try:
+            reminders = int(local_config["DEFAULTS"].get("sponsor_reminders", "0"))
+        except ValueError:
+            reminders = 0
+        if runs > 10_000 and reminders < 3:
+            print(colored("🎉 WOW! You've run poketerm over 10,000 times! 🎉", "yellow"))
+            print(
+                colored(
+                    "☕ Consider sponsoring the project: https://github.com/sponsors/terminalwelcome",
+                    "green",
+                )
+            )
+            print(colored("This message will appear only three times.", "cyan"))
+            reminders += 1
+        local_config["DEFAULTS"]["sponsor_reminders"] = str(reminders)
+
         with open(local_config_path, "w") as configfile:
             local_config.write(configfile)
-        if runs > 10_000:
-            print(
-                "You've run poketerm over 10,000 times! Consider sponsoring at "
-                "https://github.com/sponsors/terminalwelcome"
-            )
 
 def change_config(args,path):
     config = cp.ConfigParser()

--- a/src/poketermconfig.ini
+++ b/src/poketermconfig.ini
@@ -5,3 +5,4 @@ message = None
 poketerm = True
 ascii = True
 dialog = True
+runs = 0

--- a/src/poketermconfig.ini
+++ b/src/poketermconfig.ini
@@ -6,3 +6,4 @@ poketerm = True
 ascii = True
 dialog = True
 runs = 0
+sponsor_reminders = 0

--- a/src/poketermconfig.ini.default
+++ b/src/poketermconfig.ini.default
@@ -5,3 +5,4 @@ message = None
 poketerm = True
 ascii = True
 dialog = True
+runs = 0

--- a/src/poketermconfig.ini.default
+++ b/src/poketermconfig.ini.default
@@ -6,3 +6,4 @@ poketerm = True
 ascii = True
 dialog = True
 runs = 0
+sponsor_reminders = 0

--- a/tests/test_runs_counter.py
+++ b/tests/test_runs_counter.py
@@ -52,6 +52,7 @@ def test_donation_message_after_threshold() -> None:
         out = result.stdout.lower()
         assert "sponsoring" in out
         assert "only" in out and "three times" in out
+        assert "https://github.com/sponsors/devarshi16" in result.stdout
         parser = cp.ConfigParser()
         parser.read(config_path)
         defaults = parser["DEFAULTS"]
@@ -80,6 +81,7 @@ def test_donation_message_shows_only_thrice() -> None:
         result = run_cli(["-p", "noascii", "-o", "0", "-s"], env=env)
         assert result.returncode == 0
         assert "sponsor" in result.stdout.lower()
+        assert "https://github.com/sponsors/devarshi16" in result.stdout
         parser = cp.ConfigParser()
         parser.read(config_path)
         defaults = parser["DEFAULTS"]

--- a/tests/test_runs_counter.py
+++ b/tests/test_runs_counter.py
@@ -1,0 +1,55 @@
+import configparser as cp
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+def run_cli(args: list[str], env: dict[str, str] | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "src.main", *args],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_runs_counter_increment() -> None:
+    with tempfile.TemporaryDirectory() as tmp_home:
+        env = {**os.environ, "HOME": tmp_home}
+        result = run_cli(["-p", "noascii", "-o", "0", "-s"], env=env)
+        assert result.returncode == 0
+        config_path = Path(tmp_home) / ".config" / "poketerm" / "poketermconfig.ini"
+        parser = cp.ConfigParser()
+        parser.read(config_path)
+        assert parser["DEFAULTS"].getint("runs") == 1
+
+
+def test_donation_message_after_threshold() -> None:
+    with tempfile.TemporaryDirectory() as tmp_home:
+        env = {**os.environ, "HOME": tmp_home}
+        config_dir = Path(tmp_home) / ".config" / "poketerm"
+        config_dir.mkdir(parents=True)
+        config_path = config_dir / "poketermconfig.ini"
+        config_path.write_text(
+            "[DEFAULTS]\n"
+            "pokemon = pikachu\n"
+            "one-liner = False\n"
+            "message = None\n"
+            "poketerm = True\n"
+            "ascii = True\n"
+            "dialog = False\n"
+            "runs = 10000\n"
+        )
+        result = run_cli(["-p", "noascii", "-o", "0", "-s"], env=env)
+        assert result.returncode == 0
+        assert "sponsoring" in result.stdout.lower()
+        parser = cp.ConfigParser()
+        parser.read(config_path)
+        assert parser["DEFAULTS"].getint("runs") == 10001
+


### PR DESCRIPTION
## Summary
- Track total poketerm runs in the user's config file
- Remind users to sponsor the project after 10,000 runs
- Test run counter behavior and donation message

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c25e294ba4832db1805a921e989332