### PR TITLE
Add support flag to display donation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ $poketerm -t 0
 ```
 usage: main.py [-h] [-p {bulbasaur,dugtrio,meowth,pikachu,noascii}] [-l]
                [-o {0,1}] [-m MESSAGE] [-t {0,1}] [-d {0,1}] [-s]
+               [--support]
 
 Display a Custom Message, a Pokemon ASCII Art and a Random Oneliner.
 NOTE: Remember to turn off poketerm using -t 0 tag before you uninstall
@@ -63,6 +64,7 @@ optional arguments:
   -t {0,1}, --turn-on {0,1}
                         turn on poketerm [1], turn off [0]
   -s, --show            run poketerm with the active configuration
+  --support             print sponsor/donation URL and exit
 ```
 
 ## List of available pokemons

--- a/src/main.py
+++ b/src/main.py
@@ -14,6 +14,10 @@ except ImportError:  # pragma: no cover - fallback when termcolor isn't installe
 from .pokemons import pokemons
 from .one_liners import one_liners
 
+SUPPORT_URLS = [
+    "https://github.com/sponsors/devarshi16",
+]
+
 
 def _dialog_cloud(text: str) -> str:
     """Return a speech bubble around *text* with basic wrapping.
@@ -50,8 +54,13 @@ def main():
     parser.add_argument('-t','--turn-on',help='turn on poketerm [1], turn off [0]',type=int,choices=[0,1])
     parser.add_argument('-d','--dialog',help='turn dialog cloud on [1] or off [0]',type=int,choices=[0,1])
     parser.add_argument('-s','--show',help='run poketerm with the active configuration',action='store_true')
+    parser.add_argument('--support', help='print sponsor/donation URL and exit', action='store_true')
 
     args = parser.parse_args()
+    if args.support:
+        for url in SUPPORT_URLS:
+            print(url)
+        return
     '''
     print("INPUT ARGS")
     for arg in vars(args):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,7 +9,7 @@ sys.path.insert(0, str(ROOT))
 
 from src.one_liners import one_liners
 from src.pokemons import pokemons
-from src.main import _dialog_cloud
+from src.main import SUPPORT_URLS, _dialog_cloud
 
 
 def run_cli(args: list[str], env: dict[str, str] | None = None) -> subprocess.CompletedProcess:
@@ -25,6 +25,13 @@ def test_help_runs() -> None:
     result = run_cli(["-h"])
     assert result.returncode == 0
     assert "usage" in result.stdout.lower()
+
+
+def test_support_prints_links() -> None:
+    result = run_cli(["--support"])
+    assert result.returncode == 0
+    for url in SUPPORT_URLS:
+        assert url in result.stdout
 
 
 def test_show_pokemon() -> None:


### PR DESCRIPTION
## Summary
- add `--support` CLI flag to show project donation URLs
- document `--support` usage in README
- test support flag prints expected links
- keep only GitHub Sponsors link in support output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c25e2a230c832db2727e9c7c0fd745