### PR TITLE
docs: add sponsor support section

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,14 @@ $ poketerm -p noascii
 $ poketerm -m nomessage
 ```
 
+## Support the Project
+
+Poketerm is completely free and open source. If it brightens up your
+terminal and you blaze past 10,000 runs (there's a gentle reminder when
+you do!), please consider supporting its continued development.
+
+[![GitHub Sponsors](https://img.shields.io/badge/Sponsor-%E2%9D%A4-ff69b4?style=for-the-badge&logo=github-sponsors)](https://github.com/sponsors/devarshi16)
+
 ## Acknowledgments
 
 Thanks to (http://silgro.com/fortunes.txt) for their one-liner database.


### PR DESCRIPTION
## Summary
- encourage funding through new Support the Project section
- mention 10k-run reminder and link to GitHub Sponsors only

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c25e2b8f04832dad4cfe5faa090c8f